### PR TITLE
Add SponsorTable for Sponsor Logos

### DIFF
--- a/src/components/SponsorTable/SponsorImg.jsx
+++ b/src/components/SponsorTable/SponsorImg.jsx
@@ -1,0 +1,10 @@
+import styled from "styled-components"
+
+export const SponsorImg = styled.img`
+  max-width: 100%;
+  max-height: ${({ maxHeight }) => maxHeight};
+  max-width: ${({ maxWidth }) => maxWidth};
+  transition: 1s;
+`
+
+export default SponsorImg

--- a/src/components/SponsorTable/SponsorImg.jsx
+++ b/src/components/SponsorTable/SponsorImg.jsx
@@ -3,7 +3,7 @@ import styled from "styled-components"
 export const SponsorImg = styled.img`
   max-width: 100%;
   max-height: ${({ maxHeight }) => maxHeight};
-  max-width: ${({ maxWidth }) => maxWidth};
+  max-width: 90vw;
   transition: 1s;
 `
 

--- a/src/components/SponsorTable/SponsorLink.jsx
+++ b/src/components/SponsorTable/SponsorLink.jsx
@@ -1,0 +1,11 @@
+import styled from "styled-components"
+import * as styleVars from "../variable"
+
+export const SponsorLink = styled.a`
+  max-width: 100%;
+  max-height: 100%;
+  text-decoration: none;
+  color: ${styleVars.hackBlack40};
+`
+
+export default SponsorLink

--- a/src/components/SponsorTable/SponsorTable.js
+++ b/src/components/SponsorTable/SponsorTable.js
@@ -4,12 +4,14 @@ import SponsorTierContainer from "./SponsorTierContainer"
 import SponsorWrapper from "./SponsorWrapper"
 import SponsorLink from "./SponsorLink"
 import SponsorImg from "./SponsorImg"
+import Text from "./Text"
+
+import TestImg from "../../assets/images/designs/buildings.svg"
 
 const Sponsor = ({
   url,
   img,
   maxHeight = "none",
-  maxWidth = "none",
   flexBasisPercent = "none",
   paddingPercent = 2,
 }) => (
@@ -18,38 +20,32 @@ const Sponsor = ({
     paddingPercent={paddingPercent}
   >
     <SponsorLink href={url} target="_blank">
-      <SponsorImg src={img} maxHeight={maxHeight} maxWidth={maxWidth} />
+      <SponsorImg src={img} maxHeight={maxHeight} />
     </SponsorLink>
   </SponsorWrapper>
 )
 
-export const TeraSponsor = ({ url, img }) => (
-  <Sponsor
-    url={url}
-    img={img}
-    maxHeight={"25vh"}
-    maxWidth={"25vw"}
-    flexBasisPercent={90}
-  />
+const TeraSponsor = ({ url, img }) => (
+  <Sponsor url={url} img={img} maxHeight={"25vh"} flexBasisPercent={90} />
 )
 
-export const GigaSponsor = ({ url, img }) => (
-  <Sponsor url={url} img={img} maxHeight={"10vh"} flexBasisPercent={65} />
+const GigaSponsor = ({ url, img }) => (
+  <Sponsor url={url} img={img} maxHeight={"12vh"} flexBasisPercent={50} />
 )
 
-export const MegaSponsor = ({ url, img }) => (
-  <Sponsor url={url} img={img} maxHeight={"9vh"} flexBasisPercent={45} />
+const MegaSponsor = ({ url, img }) => (
+  <Sponsor url={url} img={img} maxHeight={"10vh"} flexBasisPercent={30} />
 )
 
-export const KiloSponsor = ({ url, img }) => (
-  <Sponsor url={url} img={img} maxHeight={"9vh"} flexBasisPercent={21} />
+const KiloSponsor = ({ url, img }) => (
+  <Sponsor url={url} img={img} maxHeight={"8vh"} flexBasisPercent={19} />
 )
 
-export const ByteSponsor = ({ url, img }) => (
-  <Sponsor url={url} img={img} maxHeight={"6vh"} flexBasisPercent={18} />
+const ByteSponsor = ({ url, img }) => (
+  <Sponsor url={url} img={img} maxHeight={"5vh"} flexBasisPercent={15} />
 )
 
-export const InKindSponsor = ({ url, img }) => (
+const InKindSponsor = ({ url, img }) => (
   <Sponsor
     url={url}
     img={img}
@@ -59,8 +55,43 @@ export const InKindSponsor = ({ url, img }) => (
   />
 )
 
-export const SponsorTier = ({ children }) => (
-  <SponsorTierContainer>{children}</SponsorTierContainer>
+export const SponsorTable = () => (
+  <>
+    <Text>Our Sponsors</Text>
+    <SponsorTierContainer>
+      <TeraSponsor img={TestImg} url="https://test.com" />
+    </SponsorTierContainer>
+    <SponsorTierContainer>
+      <GigaSponsor img={TestImg} url="https://test.com" />
+      <GigaSponsor img={TestImg} url="https://test.com" />
+    </SponsorTierContainer>
+    <SponsorTierContainer>
+      <MegaSponsor img={TestImg} url="https://test.com" />
+      <MegaSponsor img={TestImg} url="https://test.com" />
+      <MegaSponsor img={TestImg} url="https://test.com" />
+    </SponsorTierContainer>
+    <SponsorTierContainer>
+      <KiloSponsor img={TestImg} url="https://test.com" />
+      <KiloSponsor img={TestImg} url="https://test.com" />
+      <KiloSponsor img={TestImg} url="https://test.com" />
+      <KiloSponsor img={TestImg} url="https://test.com" />
+    </SponsorTierContainer>
+    <SponsorTierContainer>
+      <ByteSponsor img={TestImg} url="https://test.com" />
+      <ByteSponsor img={TestImg} url="https://test.com" />
+      <ByteSponsor img={TestImg} url="https://test.com" />
+      <ByteSponsor img={TestImg} url="https://test.com" />
+      <ByteSponsor img={TestImg} url="https://test.com" />
+    </SponsorTierContainer>
+    <SponsorTierContainer>
+      <InKindSponsor img={TestImg} url="https://test.com" />
+      <InKindSponsor img={TestImg} url="https://test.com" />
+      <InKindSponsor img={TestImg} url="https://test.com" />
+      <InKindSponsor img={TestImg} url="https://test.com" />
+      <InKindSponsor img={TestImg} url="https://test.com" />
+      <InKindSponsor img={TestImg} url="https://test.com" />
+    </SponsorTierContainer>
+  </>
 )
 
-export default SponsorTier
+export default SponsorTable

--- a/src/components/SponsorTable/SponsorTable.js
+++ b/src/components/SponsorTable/SponsorTable.js
@@ -1,0 +1,66 @@
+import React from "react"
+
+import SponsorTierContainer from "./SponsorTierContainer"
+import SponsorWrapper from "./SponsorWrapper"
+import SponsorLink from "./SponsorLink"
+import SponsorImg from "./SponsorImg"
+
+const Sponsor = ({
+  url,
+  img,
+  maxHeight = "none",
+  maxWidth = "none",
+  flexBasisPercent = "none",
+  paddingPercent = 2,
+}) => (
+  <SponsorWrapper
+    flexBasisPercent={flexBasisPercent}
+    paddingPercent={paddingPercent}
+  >
+    <SponsorLink href={url} target="_blank">
+      <SponsorImg src={img} maxHeight={maxHeight} maxWidth={maxWidth} />
+    </SponsorLink>
+  </SponsorWrapper>
+)
+
+export const TeraSponsor = ({ url, img }) => (
+  <Sponsor
+    url={url}
+    img={img}
+    maxHeight={"25vh"}
+    maxWidth={"25vw"}
+    flexBasisPercent={90}
+  />
+)
+
+export const GigaSponsor = ({ url, img }) => (
+  <Sponsor url={url} img={img} maxHeight={"10vh"} flexBasisPercent={65} />
+)
+
+export const MegaSponsor = ({ url, img }) => (
+  <Sponsor url={url} img={img} maxHeight={"9vh"} flexBasisPercent={45} />
+)
+
+export const KiloSponsor = ({ url, img }) => (
+  <Sponsor url={url} img={img} maxHeight={"9vh"} flexBasisPercent={21} />
+)
+
+export const ByteSponsor = ({ url, img }) => (
+  <Sponsor url={url} img={img} maxHeight={"6vh"} flexBasisPercent={18} />
+)
+
+export const InKindSponsor = ({ url, img }) => (
+  <Sponsor
+    url={url}
+    img={img}
+    maxHeight={"4vh"}
+    flexBasisPercent={7}
+    paddingPercent={1.5}
+  />
+)
+
+export const SponsorTier = ({ children }) => (
+  <SponsorTierContainer>{children}</SponsorTierContainer>
+)
+
+export default SponsorTier

--- a/src/components/SponsorTable/SponsorTierContainer.jsx
+++ b/src/components/SponsorTable/SponsorTierContainer.jsx
@@ -1,0 +1,26 @@
+import styled from "styled-components"
+import * as styleVars from "../variable"
+
+export const SponsorTierContainer = styled.div`
+  flex-wrap: wrap;
+  margin-bottom: 0.5rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  max-width: 960px;
+  margin: 0 auto;
+
+  &::after {
+    content: "''";
+    display: table;
+    clear: both;
+  }
+
+  @media only screen and (max-width: ${styleVars.smUp}) {
+    width: 85%;
+    padding: 0;
+  }
+`
+
+export default SponsorTierContainer

--- a/src/components/SponsorTable/SponsorTierContainer.jsx
+++ b/src/components/SponsorTable/SponsorTierContainer.jsx
@@ -12,7 +12,7 @@ export const SponsorTierContainer = styled.div`
   margin: 0 auto;
 
   &::after {
-    content: "''";
+    content: "";
     display: table;
     clear: both;
   }

--- a/src/components/SponsorTable/SponsorWrapper.jsx
+++ b/src/components/SponsorTable/SponsorWrapper.jsx
@@ -1,0 +1,14 @@
+import styled from "styled-components"
+
+export const SponsorWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  align-self: center;
+  align-content: center;
+  flex-direction: row;
+  flex-basis: ${({ flexBasisPercent }) => flexBasisPercent}%;
+  padding: ${({ paddingPercent }) => paddingPercent}%;
+`
+
+export default SponsorWrapper

--- a/src/components/SponsorTable/Text.jsx
+++ b/src/components/SponsorTable/Text.jsx
@@ -1,0 +1,13 @@
+import styled from "styled-components"
+import * as styleVars from "../variable"
+
+export const Text = styled.div`
+  margin: auto;
+  margin-bottom: 40px;
+  text-align: center;
+  color: ${styleVars.colorHackRed};
+  font-size: 3rem;
+  font-weight: 400;
+`
+
+export default Text


### PR DESCRIPTION
### Tickets:

- HCK-12

### List of changes:

- Added the SponsorTable component that will render all of the sponsors with different tiers (taken from the 2019 site)
- The list of tiers is: Tera, Giga, Mega, Kilo, Byte, InKind
- Created a placeholder table format to add images and URLs for sponsors later (screenshot below)
- The placeholder table is not actually rendered anywhere right now

<img width="984" alt="Screen Shot 2019-11-30 at 10 23 14 PM" src="https://user-images.githubusercontent.com/39174451/69910435-60fc0880-13c0-11ea-9392-d19233efa1e1.png">

### Type of change:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] New release
- [ ] Requires a documentation update

### How did you do this?
- Created different components for each sponsor tier and provided styles accordingly
- Used props for the width and height of each sponsor tier to create a base Sponsor component

### Why are you choosing this approach?
- Props helped reduce the duplication in the code

### Questions for code reviewers?

### PR Checklist:

- [x] Merged `develop` branch (before testing)
- [x] Ran `yarn format` to format code
- [x] Tested all links in project relevant browsers
- [x] Tested all links on different screen sizes
- [x] Referenced all useful info (issues, tasks, etc)
